### PR TITLE
fix: link navbar title to LinkedIn profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
 
   <!-- NAV -->
   <nav>
-    <a href="#hero" class="nav-logo">VSD</a>
+    <a href="https://linkedin.com/in/vishaal-sai-devisetty-9a1a35261" target="_blank" class="nav-logo">VSD</a>
     <ul class="nav-links">
       <li><a href="#skills">Skills</a></li>
       <li><a href="#experience">Experience</a></li>


### PR DESCRIPTION
Clicking the 'VSD' logo in the navbar now redirects to the LinkedIn profile page instead of the hero section.

Closes #1

Generated with [Claude Code](https://claude.ai/code)